### PR TITLE
fix mvn posterior and re-animate test

### DIFF
--- a/abismal/merging/merging.py
+++ b/abismal/merging/merging.py
@@ -172,12 +172,6 @@ class VariationalMergingModel(tfk.models.Model):
                 _hkl.flat_values,
             )
 
-            _kl_div = self.surrogate_posterior.rac.gather(
-                kl_div,
-                asu_id.flat_values,
-                _hkl.flat_values,
-            )
-            _kl_div = tf.RaggedTensor.from_row_splits(_kl_div[...,None], iobs.row_splits)
             _ipred = tf.RaggedTensor.from_row_splits(_z, iobs.row_splits)
 
             if self.surrogate_posterior.parameterization == 'structure_factor':
@@ -191,13 +185,11 @@ class VariationalMergingModel(tfk.models.Model):
                 ipred = _ipred
                 ll = _ll
                 hkl = _hkl
-                kl_div = _kl_div
             else:
                 idx =  _ll > ll
                 ipred = tf.where(idx, _ipred, ipred)
                 ll = tf.where(idx, _ll, ll)
                 hkl = tf.where(idx, _hkl, hkl)
-                kl_div = tf.where(idx, _kl_div, kl_div)
 
         if training:
             self.surrogate_posterior.register_seen(asu_id.flat_values, hkl.flat_values)

--- a/abismal/surrogate_posterior/normal.py
+++ b/abismal/surrogate_posterior/normal.py
@@ -56,6 +56,8 @@ class MultivariateNormalPosteriorBase(object):
     """
     A base class for creating low-rank multivariate normal posteriors. 
     """
+    independent = False
+
     def __init__(self, rac, rank, loc_init=None, scale_init=None, epsilon=1e-12, **kwargs):
         super().__init__(rac, epsilon=epsilon, **kwargs)
 

--- a/tests/command_line/test_cli.py
+++ b/tests/command_line/test_cli.py
@@ -110,12 +110,12 @@ def test_posteriors(conventional_mtz, kind, distribution):
     )
 
 
-@pytest.mark.xfail(reason='Not compatible with refactored merging model')
 def test_multivariate_normal_posterior(conventional_mtz):
     flags = base_flags  + (
         f"--posterior-type=structure_factor",
         f"--posterior-distribution=normal",
         f"--posterior-rank=3",
+        f"--prior-distribution=normal",
     )
     files = [
         conventional_mtz,


### PR DESCRIPTION
resurrect the multivariate normal posterior which was broken when the merging model was refactored to save memory for large posteriors. 