### PR TITLE
document tests, make testing more transparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@ pip install abismal[cuda]
 
 You can now use abismal with GPU acceleration by running `conda activate abismal`. 
 You can test GPU support by typing `abismal --list-devices`. 
+
+# Running tests
+Abismal CI runs tests on each pull request. Development installs are similar to a normal install, but it is important
+to make sure that you install `abismal[dev]` in a fresh environment. 
+Running the following commands will set up an environment. 
+```
+git clone https://github.com/rs-station/abismal.git
+cd abismal
+conda create -yn abismal -c conda-forge dials python=3.12
+conda activate abismal
+pip install -e .[dev]
+```
+
+Tests are run by calling `pytest` in the root of the abismal source code directory. 
+
+
+

--- a/abismal/command_line/abismal.py
+++ b/abismal/command_line/abismal.py
@@ -309,7 +309,8 @@ def main(args=None):
 
     logger.info("Compiling model")
     model.compile(opt, run_eagerly=parser.run_eagerly, jit_compile=parser.jit_compile)
-    if parser.debug:
+    if parser.embed:
+        logger.info("Embed selected, entering interactive, IPython shell.")
         from IPython import embed
         embed(colors='linux')
 
@@ -341,8 +342,8 @@ def main(args=None):
 
     logger.info("Finished training.")
 
-    if parser.debug:
-        logger.info("Debug mode selected, entering interactive, IPython shell.")
+    if parser.embed:
+        logger.info("Embed selected, entering interactive, IPython shell.")
         from IPython import embed
 
         embed(colors="linux")

--- a/abismal/command_line/parser/tf.py
+++ b/abismal/command_line/parser/tf.py
@@ -61,6 +61,17 @@ args_and_kwargs = (
         }
     ),
 
+
+    (
+        (
+            "--embed",
+        ),{
+            "help": "Embed into an IPython shell just before and just after the model is trained. Helpful for debugging.",
+            "action" : "store_true",
+        }
+    ),
+
+
     (
         (
             "--list-devices",

--- a/tests/command_line/test_cli.py
+++ b/tests/command_line/test_cli.py
@@ -23,7 +23,7 @@ base_flags = (
     "--shuffle-buffer-size=10",
     "--steps-per-epoch=10",
     "--num-cpus=1",
-    #"--debug",
+    "--debug",
 )
 
 def run_abismal(flags, files, additional_asserts=()):


### PR DESCRIPTION
Add a note about dev environments to the readme. Make tests easier to debug by calling the model prior to training. To do this I needed to make `--embed` a separate flag from `--debug`. 