### PR TITLE
fix dw prior and add test for execution

### DIFF
--- a/abismal/command_line/abismal.py
+++ b/abismal/command_line/abismal.py
@@ -92,6 +92,8 @@ def main(args=None):
         reindexing_ops = reindexing_ops + [op.triplet() for op in ops]
         logger.info(f"Adding disambiguation operators: {reindexing_ops}")
 
+    posterior_kwargs = {}
+
     if parser.prior_distribution == "wilson":
         if parser.parents is not None:
             from abismal.prior.structure_factor.wilson import MultiWilsonPrior
@@ -100,6 +102,7 @@ def main(args=None):
                 rac,
                 parser.prior_correlation,
             )
+            posterior_kwargs['independent'] = False
         elif parser.posterior_type == "intensity":
             from abismal.prior.intensity.wilson import WilsonPrior
 
@@ -127,12 +130,13 @@ def main(args=None):
         loc_init = tf.ones_like(prior.flat_distribution().mean())
         scale_init = parser.init_scale * loc_init
 
-    posterior_kwargs = {
+    posterior_kwargs.update({
         "rac": rac,
         "loc_init": loc_init,
         "scale_init": scale_init,
         "epsilon": parser.epsilon,
-    }
+    })
+
     if parser.posterior_type == "intensity":
         if parser.posterior_distribution == "foldednormal":
             from abismal.surrogate_posterior.intensity import (

--- a/abismal/command_line/cchalf.py
+++ b/abismal/command_line/cchalf.py
@@ -23,6 +23,9 @@ def main(args=None):
     parser.add_argument(
         "--reference-mtz", type= str, default=None, help='A reference mtz file which will be used to determine the reindexing operator.',
     )
+    parser.add_argument(
+        "--run-eagerly", help="Run eagerly which is slower but more straightforward to debug.", action='store_true',
+    )
     parser = parser.parse_args(args)
 
     import tf_keras as tfk
@@ -50,7 +53,7 @@ def main(args=None):
             opt = model.optimizer.from_config(model.optimizer.get_config()) 
 
             #Now re-compile to re-initialize the optimizer momenta
-            model.compile(opt)
+            model.compile(opt, run_eagerly=parser.run_eagerly)
 
             callbacks = [
                 MtzSaver(f"half_{half_id+1}", reference_mtz=parser.reference_mtz)

--- a/abismal/prior/structure_factor/wilson.py
+++ b/abismal/prior/structure_factor/wilson.py
@@ -114,12 +114,12 @@ class MultiWilsonDistribution:
         )
         return loc
 
-    def log_prob(self, z):
-        if self.parent_id is not None:
+    def log_prob(self, z, z_pa=None):
+        if z_pa is None:
             z_h = z
             z_pa = tf.gather(z, self.parent_id, axis=-1)
         else:
-            z_h, z_pa = tf.unstack(z, axis=-1)
+            z_h, z_pa = z[...,0],z[...,1]
 
         #Single wilson case for root nodes
         ll_sw = WilsonDistribution(self.centric, self.multiplicity, self.sigma).log_prob(z_h)

--- a/abismal/surrogate_posterior/normal.py
+++ b/abismal/surrogate_posterior/normal.py
@@ -56,10 +56,9 @@ class MultivariateNormalPosteriorBase(object):
     """
     A base class for creating low-rank multivariate normal posteriors. 
     """
-    independent = False
 
-    def __init__(self, rac, rank, loc_init=None, scale_init=None, epsilon=1e-12, **kwargs):
-        super().__init__(rac, epsilon=epsilon, **kwargs)
+    def __init__(self, rac, rank, loc_init=None, independent=False, scale_init=None, epsilon=1e-12, **kwargs):
+        super().__init__(rac, epsilon=epsilon, independent=independent, **kwargs)
 
         if loc_init is None:
             loc_init = tf.ones(rac.asu_size)

--- a/tests/command_line/test_cli.py
+++ b/tests/command_line/test_cli.py
@@ -46,7 +46,7 @@ def run_abismal(flags, files, additional_asserts=()):
         for add in additional_asserts:
             assert add()
 
-        args = " datamanager.yml epoch_2.keras --sf-init epoch_0.keras "
+        args = " datamanager.yml epoch_2.keras --run-eagerly --sf-init epoch_0.keras "
         cchalf_main(args.split())
         assert exists('abismal_xval.mtz')
 
@@ -153,4 +153,19 @@ def test_glu(conventional_mtz):
         files,
     )
 
+
+def test_multivariate_wilson_prior(conventional_mtz):
+    flags = base_flags  + (
+        f"--parents=0,0",
+        f"-r 0.0,0.99",
+        f"--prior-distribution=wilson",
+    )
+    files = [
+        conventional_mtz,
+        conventional_mtz,
+    ]
+    run_abismal(
+        flags,
+        files,
+    )
 


### PR DESCRIPTION
The main goal of this PR is to resurrect the multivariate wilson prior which was broken by changing the KL divergence calculation. This works the same way that the multivariate normal posterior was resurrected by flagging the posterior with `surrogate_posterior.independent=False`. To make this work nicely with the CLI, I changed `independent` to be set by the constructor rather than being a static attribute of the subclass. To debug this one, I found it helpful to add a `--run-eagerly` flag to `abismal.cchalf` and make it the default for testing. That leads to more helpful tracebacks when errors happen during cchalf. 