### PR TITLE
option to randomly permute the indexing ambiguity

### DIFF
--- a/abismal/command_line/abismal.py
+++ b/abismal/command_line/abismal.py
@@ -88,7 +88,7 @@ def main(args=None):
 
     reindexing_ops = ["x,y,z"]
     if not parser.disable_index_disambiguation:
-        ops = gemmi.find_twin_laws(self.cell, self.spacegroup, 3.0, False)
+        ops = gemmi.find_twin_laws(dm.cell, dm.spacegroup, 3.0, False)
         reindexing_ops = reindexing_ops + [op.triplet() for op in ops]
         logger.info(f"Adding disambiguation operators: {reindexing_ops}")
 

--- a/abismal/command_line/abismal.py
+++ b/abismal/command_line/abismal.py
@@ -88,7 +88,7 @@ def main(args=None):
 
     reindexing_ops = ["x,y,z"]
     if not parser.disable_index_disambiguation:
-        ops = gemmi.find_twin_laws(dm.cell, dm.spacegroup, 3.0, False)
+        ops = gemmi.find_twin_laws(self.cell, self.spacegroup, 3.0, False)
         reindexing_ops = reindexing_ops + [op.triplet() for op in ops]
         logger.info(f"Adding disambiguation operators: {reindexing_ops}")
 

--- a/abismal/command_line/parser/training.py
+++ b/abismal/command_line/parser/training.py
@@ -92,5 +92,13 @@ args_and_kwargs = (
         }
     ),
 
+    (
+        (
+            "--enable-index-ambiguation",
+        ),{
+            "help": "Randomize the indexing solution by a random twinning operator.",
+            "action": "store_true",
+        }
+    ),
 
 )

--- a/abismal/io/ambiguation.py
+++ b/abismal/io/ambiguation.py
@@ -1,0 +1,45 @@
+from abismal.symmetry import Op
+from reciprocalspaceship.decorators import spacegroupify,cellify
+import gemmi
+import numpy as np
+
+class Ambiguator():
+    def __init__(self, ops):
+        self.ops = [Op(op) for op in ops]
+
+    @classmethod
+    @spacegroupify
+    @cellify
+    def from_symmetry(cls, cell, spacegroup):
+        reindexing_ops = ["x,y,z"]
+        ops = gemmi.find_twin_laws(cell, spacegroup, 3.0, False)
+        reindexing_ops = reindexing_ops + [op.triplet() for op in ops]
+        return cls(reindexing_ops)
+
+    def ambiguate(self, hkl):
+        op = np.random.choice(self.ops)
+        hkl = op(hkl)
+        return hkl
+
+    def __call__(self, X, Y):
+        (
+            asu_id,
+            hkl_in,
+            resolution,
+            wavelength,
+            metadata,
+            iobs,
+            sigiobs,
+        ) = X
+        hkl = self.ambiguate(hkl_in)
+        X = (
+            asu_id,
+            hkl,
+            resolution,
+            wavelength,
+            metadata,
+            iobs,
+            sigiobs,
+        ) 
+        return (X, Y)
+

--- a/abismal/io/manager.py
+++ b/abismal/io/manager.py
@@ -41,7 +41,7 @@ class DataManager:
             num_cpus=None, separate=False, wavelength=None, ray_log_level="ERROR",
             test_fraction=0., separate_friedel_mates=False, cell_tol=None, isigi_cutoff=None, 
             shuffle_buffer_size=0, batch_size=100, steps_per_epoch=None, validation_steps=None,
-            epochs=30,
+            epochs=30, ambiguate=False
         ):
         if separate_friedel_mates and separate:
             raise ValueError("Cannot combine --separate-friedel-mates and --separate")
@@ -64,6 +64,7 @@ class DataManager:
         self.steps_per_epoch = steps_per_epoch
         self.validation_steps = validation_steps
         self.epochs = epochs
+        self.ambiguate = ambiguate
 
     def get_config(self):
         conf = {
@@ -84,6 +85,7 @@ class DataManager:
             'steps_per_epoch' : self.steps_per_epoch,
             'validation_steps' : self.validation_steps,
             'epochs' : self.epochs,
+            'ambiguate' : self.ambiguate,
         }
         return conf
 
@@ -114,6 +116,7 @@ class DataManager:
             steps_per_epoch = parser.steps_per_epoch,
             validation_steps = parser.validation_steps,
             epochs = parser.epochs,
+            ambiguate = parser.enable_index_ambiguation,
         )
 
     @property
@@ -222,6 +225,10 @@ class DataManager:
         if self.separate_friedel_mates:
             self.num_asus = 2
 
+        if self.ambiguate:
+            from abismal.io.ambiguation import Ambiguator
+            amb = Ambiguator.from_symmetry(self.cell, self.spacegroup)
+            data = data.map(amb)
         return data
 
     @property


### PR DESCRIPTION
This PR adds a debugging feature that allows testing index disambiguation on a dataset that has already been disambiguated. It applies a randomly selected reindexing operator to each image during data loading. 